### PR TITLE
建立正式環境部署、Migration 與備份流程

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ UOC_Pdf_trans/
 AI-Document-Translator/
 output_clean_html/
 pdf/
+.env.staging
+build/

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,55 @@
+# 正式環境部署與資料庫維運
+
+本專案正式環境使用 Alembic 管理 SQL Server schema。production 預設 `AUTO_SCHEMA_MANAGEMENT=0`，應用啟動時不自動建表或補欄位。
+
+## 部署流程
+
+1. 確認 `.env` 至少包含 `DATABASE_URL`、必要 OpenAI/Azure/LDAP 設定。
+2. 第一次導入既有資料庫時，如果 schema 已存在且完整，先執行 `alembic stamp head`。空資料庫或要由 migration 建表時，執行 `alembic upgrade head`。
+3. 執行 `flask --app app.py schema-preflight` 確認必要 tables/columns 完整。
+4. 執行 `flask --app app.py seed-bootstrap` 初始化 auth roles 與 bootstrap admins。
+5. 使用 `bash deploy.sh` 部署並重啟 systemd services。
+
+常用環境變數：
+
+```bash
+APP_ENV=production
+AUTO_SCHEMA_MANAGEMENT=0
+RUN_GIT_PULL=0
+RUN_DB_BACKUP=1
+INSTALL_SYSTEMD_UNITS=1
+WEB_WORKERS=4
+WEB_BIND=unix:uo_regulations_translate.sock
+```
+
+## 資料庫備份與還原
+
+部署前備份：
+
+```bash
+SQLCMD_SERVER=... SQLCMD_USER=... SQLCMD_PASSWORD=... MSSQL_DATABASE=... MSSQL_BACKUP_DIR=... \
+  bash scripts/backup_mssql_full.sh
+```
+
+原地還原會覆蓋目標資料庫，必須明確加上 `--yes`：
+
+```bash
+SQLCMD_SERVER=... SQLCMD_USER=... SQLCMD_PASSWORD=... MSSQL_DATABASE=... MSSQL_BACKUP_FILE=... \
+  bash scripts/restore_mssql_replace.sh --yes
+```
+
+## systemd
+
+只產生 unit files：
+
+```bash
+bash scripts/install_systemd_units.sh --output-dir /tmp/translate-systemd
+```
+
+安裝 unit files：
+
+```bash
+sudo bash scripts/install_systemd_units.sh --install
+sudo systemctl enable uo_regulations_translate_worker
+sudo systemctl start uo_regulations_translate uo_regulations_translate_worker
+```

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+path_separator = os
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from .extensions import init_app as init_extensions
 from .hooks import register_before_request
 from .services import state
 from .services.auth_service import init_auth
+from .services.operations_service import register_operations_cli
 
 
 
@@ -23,6 +24,7 @@ def create_app(config_name: str | None = None) -> Flask:
     app.config.from_object(config_cls)
 
     init_extensions(app)
+    register_operations_cli(app)
     init_auth(app)
     register_blueprints(app)
     register_error_handlers(app)

--- a/app/config.py
+++ b/app/config.py
@@ -1,9 +1,27 @@
 from __future__ import annotations
 
+import os
+
 from .services import state
 
 
+def parse_bool(value: object, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    return text in {"1", "true", "yes", "on"}
+
+
 class BaseConfig:
+    APP_ENV = os.getenv("APP_ENV") or os.getenv("FLASK_ENV") or "development"
+    AUTO_SCHEMA_MANAGEMENT = parse_bool(
+        os.getenv("AUTO_SCHEMA_MANAGEMENT"),
+        str(APP_ENV).strip().lower() != "production",
+    )
     SECRET_KEY = state.SECRET_KEY
     BASE_DIR = state.BASE_DIR
     OUT_ROOT = state.OUT_ROOT
@@ -75,6 +93,8 @@ class BaseConfig:
 
 
 class TestingConfig(BaseConfig):
+    APP_ENV = "testing"
+    AUTO_SCHEMA_MANAGEMENT = True
     TESTING = True
     AUTH_ENABLED = False
     AUTH_REQUIRE_LOCAL_USER = False
@@ -82,8 +102,21 @@ class TestingConfig(BaseConfig):
     OWNER_ACCESS_ENABLED = True
 
 
+class DevelopmentConfig(BaseConfig):
+    APP_ENV = "development"
+    AUTO_SCHEMA_MANAGEMENT = parse_bool(os.getenv("AUTO_SCHEMA_MANAGEMENT"), True)
+
+
+class ProductionConfig(BaseConfig):
+    APP_ENV = "production"
+    AUTO_SCHEMA_MANAGEMENT = parse_bool(os.getenv("AUTO_SCHEMA_MANAGEMENT"), False)
+    SESSION_COOKIE_SECURE = parse_bool(os.getenv("SESSION_COOKIE_SECURE"), True)
+
+
 CONFIG_BY_NAME = {
     None: BaseConfig,
     "default": BaseConfig,
+    "development": DevelopmentConfig,
+    "production": ProductionConfig,
     "testing": TestingConfig,
 }

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -316,7 +316,7 @@ def init_auth(app) -> None:
     login_manager.login_view = "auth.login"
     register_auth_handlers()
     register_auth_context(app)
-    if not app.config.get("TESTING"):
+    if not app.config.get("TESTING") and app.config.get("AUTO_SCHEMA_MANAGEMENT", True):
         auth_store.bootstrap_auth_store(app.config)
 
 

--- a/app/services/auth_store.py
+++ b/app/services/auth_store.py
@@ -349,7 +349,7 @@ def count_users_with_role(role_name: str) -> int:
             select(UserRecord.id)
             .join(UserRoleRecord, UserRoleRecord.user_id == UserRecord.id)
             .join(RoleRecord, RoleRecord.id == UserRoleRecord.role_id)
-            .where(RoleRecord.name == cleaned, UserRecord.is_active.is_(True))
+            .where(RoleRecord.name == cleaned, UserRecord.is_active == True)
         ).all()
         return len(rows)
 

--- a/app/services/job_store.py
+++ b/app/services/job_store.py
@@ -100,8 +100,10 @@ def init_app(app) -> None:
         raise RuntimeError("Only SQL Server DATABASE_URL values are supported.")
     _engine = create_engine(database_url, future=True, pool_pre_ping=True)
     _session_factory = sessionmaker(bind=_engine, future=True, expire_on_commit=False)
-    _ensure_compatible_columns()
-    _assert_required_tables()
+    if bool(app.config.get("AUTO_SCHEMA_MANAGEMENT", True)):
+        Base.metadata.create_all(bind=_engine, checkfirst=True)
+        _ensure_compatible_columns()
+        _assert_required_tables()
 
 
 def _ensure_compatible_columns() -> None:
@@ -155,6 +157,10 @@ def _assert_required_tables() -> None:
             "Missing required SQL Server column: document_templates.payload_json. "
             "Update the database schema before starting the app."
         )
+
+
+def assert_required_schema() -> None:
+    _assert_required_tables()
 
 
 def session_scope() -> contextlib.AbstractContextManager[Session]:

--- a/app/services/operations_service.py
+++ b/app/services/operations_service.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import click
+from flask import current_app
+from sqlalchemy import func, select
+
+from . import auth_store, job_store
+from .schema_control import missing_columns, missing_schema_groups, required_schema_groups
+
+
+def run_schema_preflight(app) -> dict[str, object]:
+    with app.app_context():
+        groups = required_schema_groups(app)
+        missing_tables = missing_schema_groups(app, groups)
+        missing_table_columns = missing_columns(groups)
+        return {
+            "ok": not missing_tables and not missing_table_columns,
+            "groups": groups,
+            "missing": missing_tables,
+            "missing_columns": missing_table_columns,
+        }
+
+
+def run_seed_bootstrap(app, *, include_auth: bool | None = None) -> dict[str, object]:
+    with app.app_context():
+        if include_auth is None:
+            include_auth = bool(app.config.get("AUTH_ENABLED", False))
+        requested_groups: dict[str, tuple[str, ...]] = {}
+        if include_auth:
+            requested_groups["auth"] = required_schema_groups(app).get("auth", ())
+        missing = missing_schema_groups(app, requested_groups)
+        if missing:
+            raise click.ClickException(
+                "Missing required tables for seed bootstrap: "
+                + ", ".join(f"{group}=[{', '.join(tables)}]" for group, tables in sorted(missing.items()))
+            )
+
+        result: dict[str, object] = {"auth_enabled": bool(include_auth)}
+        if include_auth:
+            auth_store.seed_roles()
+            auth_store.bootstrap_admins(app.config)
+            with job_store.session_scope() as session:
+                result["role_count"] = int(session.scalar(select(func.count()).select_from(auth_store.RoleRecord)) or 0)
+            result["admin_count"] = auth_store.count_users_with_role(auth_store.ROLE_ADMIN)
+        return result
+
+
+def register_operations_cli(app) -> None:
+    @app.cli.command("schema-preflight")
+    def schema_preflight_command() -> None:
+        result = run_schema_preflight(current_app._get_current_object())
+        if not result["ok"]:
+            parts: list[str] = []
+            missing_tables = result["missing"]
+            if missing_tables:
+                parts.append(
+                    "tables="
+                    + " ".join(
+                        f"{group}=[{', '.join(tables)}]" for group, tables in sorted(missing_tables.items())  # type: ignore[arg-type]
+                    )
+                )
+            missing_table_columns = result["missing_columns"]
+            if missing_table_columns:
+                parts.append(
+                    "columns="
+                    + " ".join(
+                        f"{table}=[{', '.join(columns)}]"
+                        for table, columns in sorted(missing_table_columns.items())  # type: ignore[arg-type]
+                    )
+                )
+            raise click.ClickException("Missing required schema: " + "; ".join(parts))
+        click.echo(
+            "schema_preflight "
+            f"ok=1 groups={len(result['groups'])} "
+            f"auto_schema_management={'1' if current_app.config.get('AUTO_SCHEMA_MANAGEMENT') else '0'}"
+        )
+
+    @app.cli.command("seed-bootstrap")
+    @click.option("--skip-auth", is_flag=True, help="Skip auth role/admin bootstrap.")
+    def seed_bootstrap_command(skip_auth: bool) -> None:
+        result = run_seed_bootstrap(
+            current_app._get_current_object(),
+            include_auth=False if skip_auth else None,
+        )
+        click.echo(
+            "seed_bootstrap "
+            f"auth={'1' if result['auth_enabled'] else '0'} "
+            f"roles={result.get('role_count', 0)} "
+            f"admins={result.get('admin_count', 0)}"
+        )

--- a/app/services/schema_control.py
+++ b/app/services/schema_control.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from sqlalchemy import inspect
+
+from . import auth_store, job_store
+
+SCHEMA_GROUPS: dict[str, tuple[str, ...]] = {
+    "jobs": ("jobs", "job_artifacts", "job_events", "document_templates"),
+    "auth": ("users", "roles", "user_roles"),
+}
+
+REQUIRED_COLUMNS: dict[str, tuple[str, ...]] = {
+    "jobs": (
+        "job_id",
+        "job_type",
+        "status",
+        "stage",
+        "progress",
+        "job_name",
+        "owner_work_id",
+        "target_lang",
+        "document_mode",
+        "payload_json",
+        "error_message",
+        "cancel_requested",
+        "retry_count",
+        "worker_id",
+        "started_at",
+        "completed_at",
+        "created_at",
+        "updated_at",
+    ),
+    "job_artifacts": ("id", "job_id", "artifact_type", "file_path", "created_at"),
+    "job_events": ("id", "job_id", "event_type", "stage", "message", "created_at"),
+    "document_templates": (
+        "template_id",
+        "name",
+        "display_name",
+        "owner_work_id",
+        "source_job_id",
+        "status",
+        "payload_json",
+        "created_at",
+        "updated_at",
+    ),
+    "users": ("id", "work_id", "display_name", "email", "is_active", "created_at", "last_login_at"),
+    "roles": ("id", "name"),
+    "user_roles": ("user_id", "role_id"),
+}
+
+
+def auto_schema_management_enabled(app) -> bool:
+    return bool(app.config.get("AUTO_SCHEMA_MANAGEMENT", True))
+
+
+def _engine():
+    engine = getattr(job_store, "_engine", None)
+    if engine is None:
+        raise RuntimeError("Database engine not initialized.")
+    return engine
+
+
+def existing_tables() -> set[str]:
+    inspector = inspect(_engine())
+    return {name.lower() for name in inspector.get_table_names()}
+
+
+def tables_exist(*table_names: str) -> bool:
+    tables = existing_tables()
+    return all(table.lower() in tables for table in table_names)
+
+
+def required_schema_groups(app) -> dict[str, tuple[str, ...]]:
+    groups = {"jobs": SCHEMA_GROUPS["jobs"]}
+    if app.config.get("AUTH_ENABLED", False):
+        groups["auth"] = SCHEMA_GROUPS["auth"]
+    return groups
+
+
+def missing_schema_groups(app, table_groups: Mapping[str, tuple[str, ...]] | None = None) -> dict[str, list[str]]:
+    groups = dict(table_groups or required_schema_groups(app))
+    tables = existing_tables()
+    missing: dict[str, list[str]] = {}
+    for group_name, required_tables in groups.items():
+        absent = [table for table in required_tables if table.lower() not in tables]
+        if absent:
+            missing[group_name] = absent
+    return missing
+
+
+def missing_columns(table_groups: Mapping[str, tuple[str, ...]] | None = None) -> dict[str, list[str]]:
+    groups = dict(table_groups or SCHEMA_GROUPS)
+    inspector = inspect(_engine())
+    tables = existing_tables()
+    missing: dict[str, list[str]] = {}
+    for required_tables in groups.values():
+        for table in required_tables:
+            if table.lower() not in tables:
+                continue
+            existing = {col["name"].lower() for col in inspector.get_columns(table)}
+            absent = [column for column in REQUIRED_COLUMNS.get(table, ()) if column.lower() not in existing]
+            if absent:
+                missing[table] = absent
+    return missing
+
+
+def ensure_auto_schema(app) -> None:
+    if not auto_schema_management_enabled(app):
+        return
+    engine = _engine()
+    job_store.Base.metadata.create_all(bind=engine, checkfirst=True)
+    auth_store.ensure_auth_schema()

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -4,6 +4,7 @@ import os
 import re
 import threading
 from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from . import openai_config
 
@@ -14,6 +15,28 @@ except Exception:  # pragma: no cover - optional import guard
 
 if callable(load_dotenv):
     load_dotenv()
+
+
+def normalize_database_url(database_url: str) -> str:
+    if not database_url.lower().startswith("mssql+pyodbc"):
+        return database_url
+    parsed = urlsplit(database_url)
+    pairs = []
+    changed = False
+    for key, value in parse_qsl(parsed.query, keep_blank_values=True):
+        if key.lower() == "trustservercertificate":
+            normalized = value.strip().lower()
+            if normalized in {"1", "true"}:
+                value = "yes"
+                changed = True
+            elif normalized in {"0", "false"}:
+                value = "no"
+                changed = True
+        pairs.append((key, value))
+    if not changed:
+        return database_url
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(pairs), parsed.fragment))
+
 
 BASE_DIR = Path(__file__).resolve().parents[2]
 OUT_ROOT = BASE_DIR / "out"
@@ -95,7 +118,7 @@ DOC_TRANSLATE_SYSTEM_PROMPT = os.getenv(
     ),
 ).strip()
 
-DATABASE_URL = os.getenv("DATABASE_URL", "").strip()
+DATABASE_URL = normalize_database_url(os.getenv("DATABASE_URL", "").strip())
 WORKER_POLL_SECONDS = float(os.getenv("WORKER_POLL_SECONDS", "3"))
 WORKER_ID = os.getenv("WORKER_ID", f"{os.getenv('COMPUTERNAME', 'worker')}-{os.getpid()}")
 WORKER_OCR_MAX_RUNNING = int(os.getenv("WORKER_OCR_MAX_RUNNING", "1"))

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="uo_regulations_translate"
+WORKER_SERVICE="uo_regulations_translate_worker"
+APP_DIR="/home/NE025/pdf_ocr_translate"
+ENV_FILE="$APP_DIR/.env"
+APP_ROOT="$APP_DIR"
+BRANCH="${DEPLOY_BRANCH:-main}"
+RUN_GIT_PULL="${RUN_GIT_PULL:-0}"
+RUN_DB_BACKUP="${RUN_DB_BACKUP:-0}"
+INSTALL_SYSTEMD_UNITS="${INSTALL_SYSTEMD_UNITS:-1}"
+WEB_WORKERS="${WEB_WORKERS:-2}"
+WEB_BIND="${WEB_BIND:-unix:$APP_ROOT/uo_regulations_translate.sock}"
+NGINX_FILE="${NGINX_FILE:-$APP_DIR/deploy/nginx.conf}"
+NGINX_SITE_NAME="${NGINX_SITE_NAME:-$APP_NAME}"
+ENABLE_NGINX="${ENABLE_NGINX:-0}"
+VENV_PYTHON="$APP_DIR/.venv/bin/python"
+ALEMBIC_BIN="$APP_DIR/.venv/bin/alembic"
+FLASK_BIN="$APP_DIR/.venv/bin/flask"
+UV_BIN="${UV_BIN:-uv}"
+
+log() {
+  printf '\n[%s] %s\n' "$(date '+%F %T')" "$1"
+}
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "Required file not found: $path" >&2
+    exit 66
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Command not found: $cmd" >&2
+    exit 127
+  fi
+}
+
+log "進入專案目錄"
+cd "$APP_DIR"
+
+require_file "$ENV_FILE"
+require_file "$VENV_PYTHON"
+
+log "載入正式環境變數"
+set -a
+source "$ENV_FILE"
+set +a
+
+export FLASK_APP=app.py
+export APP_ENV="${APP_ENV:-production}"
+export ALEMBIC_CONFIG_NAME="${ALEMBIC_CONFIG_NAME:-production}"
+export ALEMBIC_DATABASE_URL="${DATABASE_URL:-}"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is empty after loading $ENV_FILE" >&2
+  exit 64
+fi
+
+if [[ -z "${ALEMBIC_DATABASE_URL:-}" ]]; then
+  echo "ALEMBIC_DATABASE_URL is empty after loading $ENV_FILE" >&2
+  exit 64
+fi
+
+if [[ "$RUN_GIT_PULL" == "1" ]]; then
+  require_cmd git
+  log "更新程式碼"
+  git pull origin "$BRANCH"
+fi
+
+log "同步 Python 套件"
+require_cmd "$UV_BIN"
+"$UV_BIN" sync --python "$VENV_PYTHON"
+require_file "$ALEMBIC_BIN"
+require_file "$FLASK_BIN"
+
+if [[ "$RUN_DB_BACKUP" == "1" ]]; then
+  log "執行部署前資料庫備份"
+  bash "$APP_DIR/scripts/backup_mssql_full.sh"
+fi
+
+log "停止應用服務"
+sudo systemctl stop "$WORKER_SERVICE" || true
+sudo systemctl stop "$APP_NAME" || true
+
+if [[ "$INSTALL_SYSTEMD_UNITS" == "1" ]]; then
+  log "安裝或更新 systemd units"
+  sudo bash "$APP_DIR/scripts/install_systemd_units.sh" \
+    --install \
+    --app-root "$APP_ROOT" \
+    --env-file "$ENV_FILE" \
+    --web-bind "$WEB_BIND" \
+    --web-workers "$WEB_WORKERS"
+fi
+
+if [[ "$ENABLE_NGINX" == "1" ]]; then
+  require_cmd nginx
+  require_file "$NGINX_FILE"
+  log "複製 Nginx 設定"
+  sudo cp "$NGINX_FILE" "/etc/nginx/sites-available/$NGINX_SITE_NAME"
+  sudo ln -sf "/etc/nginx/sites-available/$NGINX_SITE_NAME" "/etc/nginx/sites-enabled/$NGINX_SITE_NAME"
+  log "測試 Nginx 設定"
+  sudo nginx -t
+fi
+
+log "執行資料庫 migration"
+"$ALEMBIC_BIN" upgrade head
+
+log "驗證 schema"
+"$FLASK_BIN" --app app.py schema-preflight
+
+log "初始化預設資料"
+"$FLASK_BIN" --app app.py seed-bootstrap
+
+log "啟動 Web service"
+sudo systemctl restart "$APP_NAME"
+
+log "啟動 Worker service"
+sudo systemctl restart "$WORKER_SERVICE"
+
+if [[ "$ENABLE_NGINX" == "1" ]]; then
+  log "重新載入 Nginx"
+  sudo systemctl reload nginx
+fi
+
+log "查看服務狀態"
+sudo systemctl status "$APP_NAME" --no-pager
+sudo systemctl status "$WORKER_SERVICE" --no-pager
+
+log "部署完成"

--- a/deploy/systemd/uo_regulations_translate.service
+++ b/deploy/systemd/uo_regulations_translate.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Gunicorn instance to serve uo regulations pdf translate system
+After=network.target
+
+[Service]
+User=NE025
+Group=www-data
+WorkingDirectory=/home/NE025/pdf_ocr_translate
+Environment="PATH=/home/NE025/pdf_ocr_translate/.venv/bin:/usr/bin"
+EnvironmentFile=/home/NE025/pdf_ocr_translate/.env
+ExecStart=/home/NE025/pdf_ocr_translate/.venv/bin/gunicorn --workers 4 --worker-class gthread --threads 4 --timeout 300 --bind unix:uo_regulations_translate.sock --user NE025 --group www-data -m 007 --error-logfile - wsgi:app

--- a/deploy/systemd/uo_regulations_translate.service.template
+++ b/deploy/systemd/uo_regulations_translate.service.template
@@ -1,0 +1,11 @@
+[Unit]
+Description=Gunicorn instance to serve uo regulations pdf translate system
+After=network.target
+
+[Service]
+User={{APP_USER}}
+Group=www-data
+WorkingDirectory={{APP_ROOT}}
+Environment="PATH={{APP_ROOT}}/.venv/bin:/usr/bin"
+EnvironmentFile={{ENV_FILE}}
+ExecStart={{APP_ROOT}}/.venv/bin/gunicorn --workers {{WEB_WORKERS}} --worker-class gthread --threads 4 --timeout 300 --bind {{WEB_BIND}} --user {{APP_USER}} --group www-data -m 007 --error-logfile - wsgi:app

--- a/deploy/systemd/uo_regulations_translate_worker.service
+++ b/deploy/systemd/uo_regulations_translate_worker.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=PDF OCR Translate Worker
+After=network.target
+
+[Service]
+Type=simple
+User=NE025
+Group=NE025
+WorkingDirectory=/home/NE025/pdf_ocr_translate
+Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=/home/NE025/pdf_ocr_translate/.env
+ExecStart=/home/NE025/pdf_ocr_translate/.venv/bin/python worker.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/uo_regulations_translate_worker.service.template
+++ b/deploy/systemd/uo_regulations_translate_worker.service.template
@@ -1,0 +1,17 @@
+[Unit]
+Description=PDF OCR Translate Worker
+After=network.target
+
+[Service]
+Type=simple
+User={{APP_USER}}
+Group={{APP_USER}}
+WorkingDirectory={{APP_ROOT}}
+Environment=PYTHONUNBUFFERED=1
+EnvironmentFile={{ENV_FILE}}
+ExecStart={{APP_ROOT}}/.venv/bin/python worker.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.config import BaseConfig, CONFIG_BY_NAME
+from app.services import auth_store, job_store  # noqa: F401
+from app.services.state import normalize_database_url
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = job_store.Base.metadata
+
+
+def _resolve_config_class():
+    config_name = (
+        os.environ.get("ALEMBIC_CONFIG_NAME")
+        or os.environ.get("APP_ENV")
+        or os.environ.get("FLASK_ENV")
+        or "default"
+    )
+    return CONFIG_BY_NAME.get(str(config_name).lower(), BaseConfig)
+
+
+def _database_url() -> str:
+    config_cls = _resolve_config_class()
+    database_url = normalize_database_url(os.environ.get("ALEMBIC_DATABASE_URL") or getattr(config_cls, "DATABASE_URL", ""))
+    if not database_url:
+        raise RuntimeError("Database URL is required for Alembic. Set ALEMBIC_DATABASE_URL or DATABASE_URL.")
+    config.set_main_option("sqlalchemy.url", str(database_url))
+    return str(database_url)
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    _database_url()
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,25 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/0001_baseline_schema.py
+++ b/migrations/versions/0001_baseline_schema.py
@@ -1,0 +1,27 @@
+"""baseline schema
+
+Revision ID: 0001_baseline_schema
+Revises:
+Create Date: 2026-05-29 00:00:00
+"""
+from __future__ import annotations
+
+from alembic import op
+
+from app.services import auth_store, job_store  # noqa: F401
+
+# revision identifiers, used by Alembic.
+revision = "0001_baseline_schema"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    job_store.Base.metadata.create_all(bind=bind, checkfirst=True)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    job_store.Base.metadata.drop_all(bind=bind, checkfirst=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "flask>=3.1.2",
   "flask-login>=0.6.3",
   "gunicorn>=25.3.0",
+  "alembic>=1.13.2",
   "img2table>=1.4.2",
   "ipykernel>=7.1.0",
   "jieba>=0.42.1",

--- a/scripts/backup_mssql_full.sh
+++ b/scripts/backup_mssql_full.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SQLCMD_BIN="${SQLCMD_BIN:-sqlcmd}"
+SQLCMD_SERVER="${SQLCMD_SERVER:-}"
+SQLCMD_USER="${SQLCMD_USER:-}"
+SQLCMD_PASSWORD="${SQLCMD_PASSWORD:-}"
+MSSQL_DATABASE="${MSSQL_DATABASE:-}"
+MSSQL_BACKUP_DIR="${MSSQL_BACKUP_DIR:-}"
+SQLCMD_TRUST_CERT="${SQLCMD_TRUST_CERT:-1}"
+
+require_var() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: $name" >&2
+    exit 64
+  fi
+}
+
+sql_escape() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+identifier_escape() {
+  printf "%s" "$1" | sed 's/]/]]/g'
+}
+
+command -v "$SQLCMD_BIN" >/dev/null 2>&1 || {
+  echo "sqlcmd not found: $SQLCMD_BIN" >&2
+  exit 127
+}
+
+require_var SQLCMD_SERVER
+require_var SQLCMD_USER
+require_var SQLCMD_PASSWORD
+require_var MSSQL_DATABASE
+require_var MSSQL_BACKUP_DIR
+
+timestamp="$(date +%F_%H%M%S)"
+backup_file_name="${BACKUP_FILE_NAME:-${MSSQL_DATABASE}_${timestamp}_copyonly_full.bak}"
+backup_path="${MSSQL_BACKUP_DIR%/}/${backup_file_name}"
+escaped_backup_path="$(sql_escape "$backup_path")"
+escaped_database_name="$(identifier_escape "$MSSQL_DATABASE")"
+
+query="
+SET NOCOUNT ON;
+BACKUP DATABASE [$escaped_database_name]
+TO DISK = N'$escaped_backup_path'
+WITH COPY_ONLY, INIT, COMPRESSION, CHECKSUM, STATS = 10;
+RESTORE VERIFYONLY
+FROM DISK = N'$escaped_backup_path'
+WITH CHECKSUM;
+"
+
+sqlcmd_args=(
+  -S "$SQLCMD_SERVER"
+  -U "$SQLCMD_USER"
+  -P "$SQLCMD_PASSWORD"
+  -d master
+  -b
+  -Q "$query"
+)
+
+if [[ "$SQLCMD_TRUST_CERT" == "1" ]]; then
+  sqlcmd_args+=(-C)
+fi
+
+"$SQLCMD_BIN" "${sqlcmd_args[@]}"
+
+printf 'backup_file=%s\n' "$backup_path"

--- a/scripts/install_systemd_units.sh
+++ b/scripts/install_systemd_units.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_DIR="$APP_ROOT/deploy/systemd"
+OUTPUT_DIR=""
+INSTALL_MODE=0
+UNIT_TARGET_DIR="/etc/systemd/system"
+APP_USER="$(stat -c '%U' "$APP_ROOT")"
+ENV_FILE="$APP_ROOT/.env"
+WEB_BIND="unix:uo_regulations_translate.sock"
+WEB_WORKERS="4"
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/install_systemd_units.sh [options]
+
+Options:
+  --output-dir PATH      Render unit files into PATH. Default: ./build/systemd
+  --install              Install rendered unit files into /etc/systemd/system
+  --unit-target-dir PATH Override install directory. Default: /etc/systemd/system
+  --app-root PATH        Application root. Default: repo root
+  --app-user USER        systemd User=. Default: owner of app root
+  --env-file PATH        EnvironmentFile=. Default: <app-root>/.env
+  --web-bind TARGET      Gunicorn bind. Default: unix:uo_regulations_translate.sock
+  --web-workers COUNT    Gunicorn worker count. Default: 4
+  --help                 Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --install)
+      INSTALL_MODE=1
+      shift
+      ;;
+    --unit-target-dir)
+      UNIT_TARGET_DIR="$2"
+      shift 2
+      ;;
+    --app-root)
+      APP_ROOT="$2"
+      shift 2
+      ;;
+    --app-user)
+      APP_USER="$2"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --web-bind)
+      WEB_BIND="$2"
+      shift 2
+      ;;
+    --web-workers)
+      WEB_WORKERS="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="$APP_ROOT/build/systemd"
+fi
+
+require_path() {
+  local path="$1"
+  local label="$2"
+  if [[ ! -e "$path" ]]; then
+    echo "$label not found: $path" >&2
+    exit 66
+  fi
+}
+
+require_path "$TEMPLATE_DIR" "Template directory"
+require_path "$APP_ROOT/.venv/bin/gunicorn" "Gunicorn executable"
+require_path "$APP_ROOT/.venv/bin/python" "Python executable"
+require_path "$ENV_FILE" "Environment file"
+
+mkdir -p "$OUTPUT_DIR"
+
+export APP_ROOT APP_USER ENV_FILE WEB_BIND WEB_WORKERS TEMPLATE_DIR OUTPUT_DIR
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+template_dir = Path(os.environ["TEMPLATE_DIR"])
+output_dir = Path(os.environ["OUTPUT_DIR"])
+mapping = {
+    "APP_ROOT": os.environ["APP_ROOT"],
+    "APP_USER": os.environ["APP_USER"],
+    "ENV_FILE": os.environ["ENV_FILE"],
+    "WEB_BIND": os.environ["WEB_BIND"],
+    "WEB_WORKERS": os.environ["WEB_WORKERS"],
+}
+
+for template_path in sorted(template_dir.glob("*.template")):
+    content = template_path.read_text(encoding="utf-8")
+    for key, value in mapping.items():
+        content = content.replace(f"{{{{{key}}}}}", value)
+    target_name = template_path.name.removesuffix(".template")
+    (output_dir / target_name).write_text(content, encoding="utf-8")
+    print(output_dir / target_name)
+PY
+
+if [[ "$INSTALL_MODE" -eq 1 ]]; then
+  mkdir -p "$UNIT_TARGET_DIR"
+  install -m 0644 "$OUTPUT_DIR"/uo_regulations_translate.service "$UNIT_TARGET_DIR"/uo_regulations_translate.service
+  install -m 0644 "$OUTPUT_DIR"/uo_regulations_translate_worker.service "$UNIT_TARGET_DIR"/uo_regulations_translate_worker.service
+  "$SYSTEMCTL_BIN" daemon-reload
+  echo "Installed unit files into $UNIT_TARGET_DIR"
+  echo "Next:"
+  echo "  sudo systemctl enable uo_regulations_translate_worker"
+  echo "  sudo systemctl start uo_regulations_translate uo_regulations_translate_worker"
+else
+  echo "Rendered unit files into $OUTPUT_DIR"
+fi

--- a/scripts/restore_mssql_replace.sh
+++ b/scripts/restore_mssql_replace.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "--yes" ]]; then
+  echo "Usage: $0 --yes" >&2
+  echo "This script performs an in-place RESTORE DATABASE ... WITH REPLACE." >&2
+  exit 64
+fi
+
+SQLCMD_BIN="${SQLCMD_BIN:-sqlcmd}"
+SQLCMD_SERVER="${SQLCMD_SERVER:-}"
+SQLCMD_USER="${SQLCMD_USER:-}"
+SQLCMD_PASSWORD="${SQLCMD_PASSWORD:-}"
+MSSQL_DATABASE="${MSSQL_DATABASE:-}"
+MSSQL_BACKUP_FILE="${MSSQL_BACKUP_FILE:-}"
+SQLCMD_TRUST_CERT="${SQLCMD_TRUST_CERT:-1}"
+
+require_var() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: $name" >&2
+    exit 64
+  fi
+}
+
+sql_escape() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+identifier_escape() {
+  printf "%s" "$1" | sed 's/]/]]/g'
+}
+
+command -v "$SQLCMD_BIN" >/dev/null 2>&1 || {
+  echo "sqlcmd not found: $SQLCMD_BIN" >&2
+  exit 127
+}
+
+require_var SQLCMD_SERVER
+require_var SQLCMD_USER
+require_var SQLCMD_PASSWORD
+require_var MSSQL_DATABASE
+require_var MSSQL_BACKUP_FILE
+
+escaped_backup_file="$(sql_escape "$MSSQL_BACKUP_FILE")"
+escaped_database_name="$(identifier_escape "$MSSQL_DATABASE")"
+
+query="
+SET NOCOUNT ON;
+BEGIN TRY
+    ALTER DATABASE [$escaped_database_name] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    RESTORE DATABASE [$escaped_database_name]
+    FROM DISK = N'$escaped_backup_file'
+    WITH REPLACE, RECOVERY, CHECKSUM, STATS = 10;
+    ALTER DATABASE [$escaped_database_name] SET MULTI_USER;
+END TRY
+BEGIN CATCH
+    BEGIN TRY
+        ALTER DATABASE [$escaped_database_name] SET MULTI_USER;
+    END TRY
+    BEGIN CATCH
+    END CATCH;
+    THROW;
+END CATCH;
+"
+
+sqlcmd_args=(
+  -S "$SQLCMD_SERVER"
+  -U "$SQLCMD_USER"
+  -P "$SQLCMD_PASSWORD"
+  -d master
+  -b
+  -Q "$query"
+)
+
+if [[ "$SQLCMD_TRUST_CERT" == "1" ]]; then
+  sqlcmd_args+=(-C)
+fi
+
+"$SQLCMD_BIN" "${sqlcmd_args[@]}"
+
+printf 'restored_database=%s\n' "$MSSQL_DATABASE"
+printf 'backup_file=%s\n' "$MSSQL_BACKUP_FILE"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,12 @@ def client(app):
 
 
 @pytest.fixture(autouse=True)
-def clean_document_templates(app, monkeypatch, tmp_path):
+def clean_document_templates(request, monkeypatch, tmp_path):
+    if "app" not in request.fixturenames:
+        yield
+        return
+
+    request.getfixturevalue("app")
     monkeypatch.setattr(state, "DOCUMENT_TEMPLATES_PATH", tmp_path / "document_templates.json")
     with job_store.session_scope() as session:
         session.execute(delete(job_store.DocumentTemplateRecord))

--- a/tests/test_alembic_baseline.py
+++ b/tests/test_alembic_baseline.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+
+from app.services.schema_control import SCHEMA_GROUPS
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_alembic_upgrade_head_creates_baseline_schema(monkeypatch, tmp_path):
+    db_path = tmp_path / "alembic.sqlite"
+    db_url = f"sqlite:///{db_path}"
+
+    monkeypatch.setenv("ALEMBIC_DATABASE_URL", db_url)
+    monkeypatch.setenv("ALEMBIC_CONFIG_NAME", "testing")
+
+    cfg = Config(str(ROOT / "alembic.ini"))
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(db_url)
+    tables = set(inspect(engine).get_table_names())
+    required_tables = {table for group in SCHEMA_GROUPS.values() for table in group}
+
+    assert required_tables.issubset(tables)
+
+    with engine.connect() as conn:
+        revision = conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+
+    assert revision == "0001_baseline_schema"

--- a/tests/test_app_config_runtime.py
+++ b/tests/test_app_config_runtime.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from app import create_app
+from app.config import ProductionConfig
+from app.services import auth_service, job_store
+
+
+def test_production_config_disables_startup_schema_management():
+    assert ProductionConfig.APP_ENV == "production"
+    assert ProductionConfig.AUTO_SCHEMA_MANAGEMENT is False
+
+
+def test_production_does_not_run_startup_schema_mutations(monkeypatch):
+    with monkeypatch.context() as scoped:
+        scoped.setattr(ProductionConfig, "DATABASE_URL", "mssql+pyodbc://unit-test")
+        scoped.setattr(ProductionConfig, "AUTH_ENABLED", True)
+
+        class FakeEngine:
+            pass
+
+        scoped.setattr(job_store, "create_engine", lambda *args, **kwargs: FakeEngine())
+        scoped.setattr(job_store, "sessionmaker", lambda *args, **kwargs: lambda: None)
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("startup schema mutation should not run in production")
+
+        scoped.setattr(job_store.Base.metadata, "create_all", fail_if_called)
+        scoped.setattr(job_store, "_ensure_compatible_columns", fail_if_called)
+        scoped.setattr(auth_service.auth_store, "bootstrap_auth_store", fail_if_called)
+
+        app = create_app("production")
+
+        assert app.config["AUTO_SCHEMA_MANAGEMENT"] is False

--- a/tests/test_operations_cli.py
+++ b/tests/test_operations_cli.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.services import job_store, operations_service
+from app.services.operations_service import register_operations_cli
+
+
+@pytest.fixture
+def ops_app(monkeypatch):
+    engine = create_engine("sqlite:///:memory:", future=True)
+    job_store.Base.metadata.create_all(bind=engine, checkfirst=True)
+    monkeypatch.setattr(job_store, "_engine", engine)
+    monkeypatch.setattr(
+        job_store,
+        "_session_factory",
+        sessionmaker(bind=engine, future=True, expire_on_commit=False),
+    )
+
+    app = Flask(__name__)
+    app.config.update(
+        AUTH_ENABLED=True,
+        AUTO_SCHEMA_MANAGEMENT=False,
+        BOOTSTRAP_ADMIN="admin1",
+    )
+    register_operations_cli(app)
+    return app
+
+
+def test_schema_preflight_fails_when_required_tables_missing(ops_app, monkeypatch):
+    monkeypatch.setattr(
+        operations_service,
+        "required_schema_groups",
+        lambda _app: {"ops": ("__missing_table__",)},
+    )
+
+    runner = ops_app.test_cli_runner()
+    result = runner.invoke(args=["schema-preflight"])
+
+    assert result.exit_code != 0
+    assert "__missing_table__" in result.output
+
+
+def test_seed_bootstrap_can_skip_auth(ops_app):
+    runner = ops_app.test_cli_runner()
+    result = runner.invoke(args=["seed-bootstrap", "--skip-auth"])
+
+    assert result.exit_code == 0
+    assert "auth=0" in result.output
+
+
+def test_seed_bootstrap_populates_auth_defaults(ops_app):
+    runner = ops_app.test_cli_runner()
+    result = runner.invoke(args=["seed-bootstrap"])
+
+    assert result.exit_code == 0
+    assert "auth=1" in result.output
+    assert "roles=2" in result.output
+    assert "admins=1" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -31,6 +31,21 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -994,6 +1009,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1444,6 +1471,7 @@ name = "paddleocr"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "chandra-ocr" },
     { name = "colorlog" },
     { name = "fastapi" },
@@ -1483,6 +1511,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.13.2" },
     { name = "chandra-ocr", specifier = ">=0.2.0" },
     { name = "colorlog", specifier = ">=6.10.1" },
     { name = "fastapi", specifier = ">=0.128.6" },


### PR DESCRIPTION
停用正式環境啟動時自動建表

導入 Alembic baseline migration

新增 schema-preflight 與 seed-bootstrap CLI

新增 MSSQL 備份與還原腳本

新增 systemd template 與安裝腳本

新增 deploy.sh 與操作文件